### PR TITLE
Add `gen_msg` property to `SimpleError`

### DIFF
--- a/scripts/simple_error.gd
+++ b/scripts/simple_error.gd
@@ -21,6 +21,12 @@ var err_code: int :
 			err_code = value
 		else:
 			assert(false, "Tried to set immutable variable.")
+var gen_msg: String :
+	set(value):
+		if _initializing:
+			gen_msg = value
+		else:
+			assert(false, "Tried to set immutable variable.")
 var output: String :
 	set(value):
 		if _initializing:
@@ -28,11 +34,12 @@ var output: String :
 		else:
 			assert(false, "Tried to set immutable variable.")
 
-func _init(src: Object, msg: String, err_code: int = -1):
+func _init(src: Object, msg: String, err_code: int = -1, gen_msg: String = ""):
 	_initializing = true
 	self.src = src
 	self.msg = msg
 	self.err_code = err_code
+	self. gen_msg = gen_msg
 	self.output = _get_output()
 	_initializing = false
 
@@ -48,10 +55,13 @@ func _get_output() -> String:
 		src_string = src.resource_path
 	
 	# Create the error string:
-	var err_string
+	var ec = ""
 	if not err_code == -1:
-		err_string = "Error(src: \"%s\", msg: \"%s\", err_code: \"%s\")" % [src_string, msg, err_code]
-	else:
-		err_string = "Error(src: \"%s\", msg: \"%s\")" % [src_string, msg]
+		ec = ", err_code: \"%s\"" % err_code
+	var gm = ""
+	if not gen_msg.is_empty():
+		gm = ", gen_msg: \"%s\"" % gen_msg
+	
+	var err_string = "Error(src: \"%s\", msg: \"%s\"%s%s)" % [src_string, msg, ec, gm]
 	
 	return err_string


### PR DESCRIPTION
Added the `gen_msg` property to `SimpleError`, but did not yet implement other requirements specified in issue #23.